### PR TITLE
Use latest released version of 107-Arduino-BoostUnits from library manager.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -21,7 +21,7 @@ jobs:
       LIBRARIES: |
         # Install the library from the local path.
         - source-path: ./
-        - source-url: https://github.com/107-systems/107-Arduino-BoostUnits.git
+        - name: 107-Arduino-BoostUnits
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Instead of latest version on master/main for CI build.