### PR TITLE
Drop `const` this specific for `get`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ public:
   { }
   virtual ~DummyPressureSensor() { }
 
-  virtual void get(drone::unit::Pressure & val) const override { val = drone::unit::Pressure(1023.0 * drone::unit::pascal); }
+  virtual void get(drone::unit::Pressure & val) override { val = drone::unit::Pressure(1023.0 * drone::unit::pascal); }
   void onExternalEvent() { onSensorValueUpdate(drone::unit::Pressure(65.8 * drone::unit::pascal)); }
 };
 /* ... */

--- a/examples/DummyPressureSensor/DummyPressureSensor.ino
+++ b/examples/DummyPressureSensor/DummyPressureSensor.ino
@@ -33,7 +33,7 @@ public:
   virtual ~DummyPressureSensor() { }
 
 
-  virtual void get(drone::unit::Pressure & val) const override { val = drone::unit::Pressure(1023.0 * drone::unit::pascal); }
+  virtual void get(drone::unit::Pressure & val) override { val = drone::unit::Pressure(1023.0 * drone::unit::pascal); }
 
   void onExternalEvent()
   {

--- a/src/107-Arduino-Sensor.hpp
+++ b/src/107-Arduino-Sensor.hpp
@@ -58,7 +58,7 @@ public:
   inline unit::Frequency updateRate() const { return _update_rate; }
 
 
-  virtual void get(T & val) const = 0;
+  virtual void get(T & val) = 0;
 
 
   virtual size_t printTo(Print & p) const override


### PR DESCRIPTION
It is unnecessarily constraining derived classes since they might need to call non-const functions in order to retrieve data from a sensor.